### PR TITLE
add: Reset-SiteSearchIndex script

### DIFF
--- a/PowerShell/Reset-SiteSearchIndex/Reset-SiteSearchIndex.md
+++ b/PowerShell/Reset-SiteSearchIndex/Reset-SiteSearchIndex.md
@@ -1,0 +1,52 @@
+# Reset-SiteSearchIndex
+
+## SYNOPSIS
+This script allows you to reset the search index for a specific site collection or a set of site collections.
+> [!WARNING]  
+> Be careful when using this script. Resetting the search index of site might cause heavy loads on the search index process of your tenant.
+
+## SOURCE
+https://github.com/dlw-digitalworkplace/dw-script-lib/tree/main/PowerShell/Reset-SiteSearchIndex
+
+## AUTHOR
+ - Name: Robin Agten
+ - Email: robin.agten@delaware.pro
+
+## Prerequisites
+ - PnP.PowerShell v1.22 (will be installed automatically if not available)
+
+## Description
+This script will follow the following execution path:
+1. Install PnP.PowerShell if not available
+2. Check if the `allSiteCollections` flag is enables
+3. If enabled:
+    1. Validate if the sp admin url is provided
+    2. Validate and warn if no url filter is provided
+    3. Fetch all site collections
+    4. Loop all site collections and reindex
+4. Else:
+    1. Validate if the site collection url is provided
+    2. Reindex the site collection
+
+## EXAMPLES
+
+### EXAMPLE 1 - Single site collection
+```powershell
+.\Reset-SiteSearchIndex.ps1 -siteCollectionUrl "https://site.sharepoint.com/sites/sitecollection1"
+```
+
+### EXAMPLE - Multiple site collections
+All site collections containing '/contoso-' in the url will be reset
+```powershell
+.\Reset-SiteSearchIndex.ps1 -multipleSiteCollections -spAdminUrl "https://agtenrdev-admin.sharepoint.com" -siteCollectionUrlFilter '/contoso-'
+```
+
+### EXAMPLE - All site collections
+All site collections containing '/contoso-' in the url will be reset
+```powershell
+.\Reset-SiteSearchIndex.ps1 -multipleSiteCollections -spAdminUrl "https://agtenrdev-admin.sharepoint.com"
+```
+
+## Tags
+ * SharePoint
+ * Search

--- a/PowerShell/Reset-SiteSearchIndex/Reset-SiteSearchIndex.ps1
+++ b/PowerShell/Reset-SiteSearchIndex/Reset-SiteSearchIndex.ps1
@@ -1,0 +1,65 @@
+
+Param(
+    [Parameter(Mandatory=$false)]
+    [string]$spAdminUrl,
+    [Parameter(Mandatory=$false)]
+    [string]$siteCollectionUrl,
+    [Parameter(Mandatory=$false)]
+    [string]$siteCollectionUrlFilter,
+    [switch]$multipleSiteCollections
+)
+
+# Install PnP.PowerShell v1.22 if not already installed
+if (-not (Get-Module -Name "PnP.PowerShell" -ListAvailable)) {
+  Install-Module -Name "PnP.PowerShell@1.22" -Scope CurrentUser -Force
+}
+
+if ($multipleSiteCollections) {
+  # Sp admin url is required in case of all site collections
+  if ($spAdminUrl -eq $null -or $spAdminUrl -eq "") {
+    Write-Host -f Red "The SharePoint admin URL is required!"
+    Exit
+  }
+
+  # Check if the site collection url filter is provided, if not show a warning asking to continue
+  if ($siteCollectionUrlFilter -eq $null -or $siteCollectionUrlFilter -eq "") {
+    Write-Host -f Magenta "You are about to reset the search index for all site collections. Do you want to continue? (Y/N)"
+    $continue = Read-Host
+    if ($continue -ne "Y") {
+      Exit
+    }
+  }
+
+  # Connect to the SharePoint admin center
+  Write-Host -f Yellow "Connecting to SharePoint admin center: $spAdminUrl ..."
+  Connect-PnPOnline -Url $spAdminUrl -Interactive
+
+  # Get all site collections
+  Write-Host -f Yellow "Getting all site collections ..."
+  if ($siteCollectionUrlFilter -eq $null -or $siteCollectionUrlFilter -eq "") {
+    $siteCollections = Get-PnPTenantSite
+  } else {
+    $siteCollections = Get-PnPTenantSite | Where-Object { $_.Url -like "*$($siteCollectionUrlFilter)*" }
+  }
+  Write-Host -f Green "Found $($siteCollections.Count) site collections"
+
+  ForEach ($site in $siteCollections) {
+    # Reset search index for the specified site collection
+    Write-Host -f Yellow "Resetting search index for site: $($site.Url) ..."
+    Connect-PnPOnline -Url $site.Url -Interactive
+    Request-PnPReIndexWeb
+    Write-Host -f Green "Resetted search index for site: $($site.Url)"
+  }
+} Else {
+  # Site collection url is required in case of single site collection
+  if ($siteCollectionUrl -eq $null -or $siteCollectionUrl -eq "") {
+    Write-Host -f Red "The site collection URL is required!"
+    Exit
+  } 
+
+  # Reset search index for the specified site collection
+  Write-Host -f Yellow "Resetting search index for site: $siteCollectionUrl ..."
+  Connect-PnPOnline -Url $siteCollectionUrl -Interactive
+  Request-PnPReIndexWeb
+  Write-Host -f Green "Resetted search index for site: $siteCollectionUrl"
+}

--- a/PowerShell/toc.yml
+++ b/PowerShell/toc.yml
@@ -8,6 +8,8 @@
   href: Explore-MicrosoftGraphModule/Explore-MicrosoftGraphModule.md
 - name: Import-KeyVaultFromExcel
   href: Import-KeyVaultFromExcel/Import-KeyVaultFromExcel.md
+- name: Reset-SiteSearchIndex
+  href: Reset-SiteSearchIndex/Reset-SiteSearchIndex.md
 - name: Reset-UserStorageQuota
   href: Reset-UserStorageQuota/Reset-UserStorageQuota.md
 - name: Restore-DeletedTermSet


### PR DESCRIPTION
## Reset-SiteSearchIndex
This script allows you to reset the search index for a specific site collection or a set of site collections.
 - [x] Your script is added to a new folder inside the `powershell` subdirectory
 - [x] The folder contains 1 PowerShell file
 - [x] The PowerShell file follows the correct naming convention
 - [x] The folder contains 1 Readme file
 - [x] The readme file is based on the correct template
