### PR TITLE
fix: Toc folder path to Add-GraphPermissionsToManagedIdentity

### DIFF
--- a/PowerShell/toc.yml
+++ b/PowerShell/toc.yml
@@ -17,4 +17,4 @@
 - name: Set-TeamsPolicyToAadGroup
   href: Set-TeamsPolicyToAadGroup/Set-TeamsPolicyToAadGroup.md
 - name: Add-GraphPermissionsToManagedIdentity
-  href: Add-GraphPermissionsToManagedIdentity.md
+  href: Add-GraphPermissionsToManagedIdentity/Add-GraphPermissionsToManagedIdentity.md


### PR DESCRIPTION
## Default
What type of change are you submitting
- [x] Bugfix
- [ ] Feature
- [ ] Other

## Description
The TOC link to Add-GraphPermissionsToManagedIdentity is currently broken; This PR fixes that
