### PR TITLE
Add: Set-DirectoryClassificationSetting

### DIFF
--- a/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.md
+++ b/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.md
@@ -1,0 +1,50 @@
+# Set-DirectoryClassificationSetting
+
+## SYNOPSIS
+This script allows you to set the allowed classification list and creates a new group setting object if not already present.
+
+Originally this script was also going to include setting the `DefaultClassification` & `ClassificationDescriptions` settings, but at the time of making the script these give HTTP 500 errors (beta endpoints be like 😉), if required, these can be added in the same way as the `ClassificationList` setting.
+
+> [!WARNING]
+> This script uses commands that are still in beta!
+
+## SOURCE
+https://github.com/dlw-digitalworkplace/dw-script-lib/tree/main/PowerShell/Set-DirectoryClassificationSetting
+
+## AUTHOR
+ - Name: Ewout Hebbrecht
+ - Email: ewout.hebbrecht@delaware.pro
+ - Original creator: Nick Sevens
+ - Original creator email: nick.sevens@delaware.pro
+
+## Prerequisites
+ - An app registration with graph application `Directory.ReadWrite.All` permission, for Workspaces this should be the main app registration.
+ - A certificate added to the same app registration for authentication, this certificate is also installed on your machine for use
+
+## Description
+This script will follow the following execution path:
+1. Install `Microsoft.Graph` & `Microsoft.Graph.Beta` if not already installed
+2. Get existing `Group.Unified` setting
+3. Create new `Group.Unified` setting if none was found
+4. Set `ClassificationList` if value is provided
+
+## Parameters
+| Variable name          | Mandatory | Variable Description                                                                | Example                                  |
+|------------------------|-----------|-------------------------------------------------------------------------------------|------------------------------------------|
+| $ClassificationList    | False     | A comma-delimited list of valid classification values that can be applied to Microsoft 365 groups.     | Internal,Confidential |
+| $TenantId              | True      | The tenant ID of the app registration                                               | 00000000-0000-0000-0000-000000000000     |
+| $ClientId              | True      | The client ID of the app registration                                               | 00000000-0000-0000-0000-000000000000     |
+| $CertificateThumbprint | True      | The thumprint of the certificate installed on the app registration                  | a909502dd82ae41433e6f83886b00d4277a32a7b |
+- All parameters are of type string
+
+## EXAMPLES
+
+### EXAMPLE 1
+This will set the `ClassificationList` setting.
+```powershell
+.\Set-DirectoryClassificationSetting -ClassificationList "Internal,Confidential" -TenantId "00000000-0000-0000-0000-000000000000" -ClientId "00000000-0000-0000-0000-000000000000" -CertificateThumbprint "a909502dd82ae41433e6f83886b00d4277a32a7b"
+```
+
+## Tags
+ * Azure AD
+ * Graph

--- a/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.md
+++ b/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.md
@@ -1,7 +1,7 @@
 # Set-DirectoryClassificationSetting
 
 ## SYNOPSIS
-This script allows you to set the allowed classification list and creates a new group setting object if not already present.
+This script allows you to set the allowed classification list and creates a new group setting object if not already present. It also shown a warning if `EnableMIPLabels` is set to true, this would mean that the classification settings will be ignored.
 
 Originally this script was also going to include setting the `DefaultClassification` & `ClassificationDescriptions` settings, but at the time of making the script these give HTTP 500 errors (beta endpoints be like 😉), if required, these can be added in the same way as the `ClassificationList` setting.
 

--- a/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.ps1
+++ b/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.ps1
@@ -56,6 +56,12 @@ try {
         Write-Host "INFO: Created new setting with ID '$($Setting.Id)' from template with ID '$TemplateId'" -ForegroundColor Yellow
     }
 
+    # Check if EnableMIPLabels is set to true
+    $EnableMIPLabels = ($Setting.Values | Where-Object { $_.Name -eq "EnableMIPLabels" }).Value
+    if ($null -ne $EnableMIPLabels -and $EnableMIPLabels -eq "true") {
+        Write-Host "WARNING: 'EnableMIPLabels' is set to 'true', classification settings will be ignored and sensitivity labels published in Microsoft Purview compliance portal will be used instead" -ForegroundColor Red
+    }
+
     # Update the existing setting
     Write-Host "INFO: Updating setting with new values" -ForegroundColor Green
 

--- a/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.ps1
+++ b/PowerShell/Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.ps1
@@ -1,0 +1,89 @@
+param (
+    [Parameter(Mandatory = $false)]
+    [string]$ClassificationList,
+    [Parameter(Mandatory = $true)]
+    [string]$TenantId,
+    [Parameter(Mandatory = $true)]
+    [string]$ClientId,
+    [Parameter(Mandatory = $true)]
+    [string]$CertificateThumbprint 
+)
+
+# Setting value names
+$ClassificationListSettingName = "ClassificationList"
+
+Write-Host "INFO: Installing required modules" -ForegroundColor Green
+
+# Install-module Microsoft.Graph if needed
+if (Get-Module -ListAvailable -Name Microsoft.Graph) {
+    Write-Host "INFO: Module Microsoft.Graph exists." -ForegroundColor Magenta
+}
+else {
+    Write-Host "INFO: Installing Microsoft.Graph..." -ForegroundColor Magenta
+    Install-Module Microsoft.Graph -AllowClobber -Repository PSGallery -Force
+}
+
+# Install-module Microsoft.Graph.Beta if needed
+if (Get-Module -ListAvailable -Name Microsoft.Graph.Beta) {
+    Write-Host "INFO: Module Microsoft.Graph.Beta exists." -ForegroundColor Magenta
+}
+else {
+    Write-Host "INFO: Installing Microsoft.Graph.Beta..." -ForegroundColor Magenta
+    Install-Module Microsoft.Graph.Beta -AllowClobber -Repository PSGallery -Force
+}
+
+Write-Host "INFO: Installed all required modules" -ForegroundColor Green
+
+Connect-MgGraph -ClientId $ClientId -TenantId $TenantId -CertificateThumbprint $CertificateThumbprint
+
+try {
+    # Try to get the existing setting
+    $Setting = Get-MgBetaDirectorySetting | Where-Object { $_.DisplayName -eq "Group.Unified"}
+
+    if ($null -eq $Setting) {
+        # Create a new setting
+        Write-Host "INFO: No existing setting found, creating new setting" -ForegroundColor Yellow
+
+        # Get the template setting ID
+        $TemplateId = (Get-MgBetaDirectorySettingTemplate | Where-Object { $_.DisplayName -eq "Group.Unified" }).Id
+
+        # Create the setting using the template
+        New-MgBetaDirectorySetting -TemplateId $TemplateId
+
+        # Get the newly created setting
+        $Setting = Get-MgBetaDirectorySetting | Where-Object { $_.DisplayName -eq "Group.Unified"}
+
+        Write-Host "INFO: Created new setting with ID '$($Setting.Id)' from template with ID '$TemplateId'" -ForegroundColor Yellow
+    }
+
+    # Update the existing setting
+    Write-Host "INFO: Updating setting with new values" -ForegroundColor Green
+
+    # Set ClassificationList if not empty
+    if ($null -ne $ClassificationList) {
+        Write-Host "INFO: Setting '$ClassificationListSettingName'" -ForegroundColor Cyan
+
+        # Create the parameters object
+        $Params = @{
+            Values = @(
+                @{
+                    Name = $ClassificationListSettingName
+                    Value = $ClassificationList
+                }
+            )
+        }
+
+        # Update the setting
+        Update-MgBetaDirectorySetting -DirectorySettingId $Setting.Id -BodyParameter $Params
+
+        Write-Host "INFO: Set '$ClassificationListSettingName' with value '$ClassificationList'" -ForegroundColor Cyan
+    }
+
+    Write-Host "INFO: successfully updated directory settings. Exiting script" -ForegroundColor Green
+}
+catch {
+    Write-Host "ERROR: Failed to update setting. Exiting script" -ForegroundColor Red
+}
+
+# Disconnect
+Disconnect-MgGraph

--- a/PowerShell/toc.yml
+++ b/PowerShell/toc.yml
@@ -18,3 +18,5 @@
   href: Set-TeamsPolicyToAadGroup/Set-TeamsPolicyToAadGroup.md
 - name: Add-GraphPermissionsToManagedIdentity
   href: Add-GraphPermissionsToManagedIdentity/Add-GraphPermissionsToManagedIdentity.md
+- name: Set-DirectoryClassificationSetting
+  href: Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.md


### PR DESCRIPTION
## Set-DirectoryClassificationSetting
This script allows you to set the allowed classification list and creates a new group setting object if not already present. It also shown a warning if `EnableMIPLabels` is set to true, this would mean that the classification settings will be ignored.

Script is an update from the `Set-AADSiteClassification.ps1` script from the workspaces repo, this is an updated version using the new Microsoft Graph PowerShell module.

Originally this script was also going to include setting the `DefaultClassification` & `ClassificationDescriptions` settings like the original, but at the time of making the script setting these will give a HTTP 500 error (beta endpoints be like 😉), if required, these can be added in the same way as the `ClassificationList` setting.
I also tested this via graph explorer, and got the same error, so seems related to graph itself. Unless it's permissions which I id not check, but I would find it weird that these similar settings would have a different or even a more restrictive permission.


 - [X] Your script is added to a new folder inside the `powershell` subdirectory
 - [X] The folder contains 1 PowerShell file
 - [X] The PowerShell file follows the correct naming convention
 - [X] The folder contains 1 Readme file
 - [X] The readme file is based on the correct template
