### PR TITLE
Add script to set metadata on all the files in a document library based on the metadata of the parent folder

### DIFF
--- a/PowerShell/Set-FileMetadataFromParentFolder/Set-FileMetadataFromParentFolder.md
+++ b/PowerShell/Set-FileMetadataFromParentFolder/Set-FileMetadataFromParentFolder.md
@@ -1,0 +1,61 @@
+# Set-FileMetadataFromParentFolder
+
+## SYNOPSIS
+
+This script updates the metadata of files based on the parent folder in a SharePoint document library. It ensures that files get the same metadata as their parent folder, one level above.
+
+## SOURCE
+
+https://github.com/dlw-digitalworkplace/dw-script-lib/tree/main/PowerShell/Set-FileMetadataFromParentFolder
+
+## AUTHOR
+
+- Name: Arne Meersman
+- Email: arne.meersman@delaware.pro
+
+## SYNTAX
+
+### Update file metadata based on parent folder
+
+```powershell
+Set-FileMetadataFromParentFolder -ClientId <String> -SiteUrl <String> -LibraryName <String> -FieldsToCheck <String[]> [-StartId <Int>] [-EndId <Int>]
+```
+
+## Prerequisites
+
+The following PowerShell modules need to be installed:
+
+- PnP PowerShell
+
+To successfully execute this script, the following prerequisites must be met:
+
+- You have the necessary permissions to make changes to the files in the library.
+- Ensure metadata fields are configured in the SharePoint library. !!If there is no metadata on the parent folder, the metadata on its child files will be removed!!
+
+## Description
+
+This script updates the metadata of files based on the parent folder in a SharePoint document library. It ensures that files get the same metadata as their parent folder, one level above. Additionally, you have the option to define a start and end point to run the script for a specific section of the library or to execute the script in smaller parts. You also have the ability to choose which metadata fields you want to copy to the files.
+
+## EXAMPLES
+
+### EXAMPLE 1: Don't use startId & endId
+
+Set metadata based on parent folders for the following metadata fields: Project, Project Name, Field3, Field4. In this example we go over the whole library.
+
+```powershell
+.\Set-MetadataBasedOnParent.ps1 -clientId "your-client-id" -siteUrl "https://contoso.sharepoint.com/sites/example" -libraryName "Documents" -fieldsToCheck @("Project", "Project_x0020_Name", "Field3", "Field4")
+```
+
+### EXAMPLE 2: Use startId & endId
+
+Set metadata based on parent folders for the following metadata fields: Project, Project Name, Field3, Field4. In this example we use the startId and endId to edit files with Id between 100000 and 200000.
+
+```powershell
+.\Set-MetadataBasedOnParent.ps1 -clientId "your-client-id" -siteUrl "https://contoso.sharepoint.com/sites/example" -libraryName "Documents" -fieldsToCheck @("Project", "Project_x0020_Name", "Field3", "Field4") -startId 100000 -endId 200000
+```
+
+## Tags
+
+- SharePoint
+- PnP.PowerShell
+- Metadata Management

--- a/PowerShell/Set-FileMetadataFromParentFolder/Set-FileMetadataFromParentFolder.ps1
+++ b/PowerShell/Set-FileMetadataFromParentFolder/Set-FileMetadataFromParentFolder.ps1
@@ -1,0 +1,129 @@
+# Description
+## This script updates the metadata of files based on the parent folder in a SharePoint document library. It ensures that files get the same metadata as their parent folder. Additionally, you have the option to define a start and end point and you can choose which metadata fields you want to copy.
+
+# Attention points
+## Try to execute the script on your own dev tenant before using somewhere else, script has only been used on "Managed Metadata", "	Single line of text", and "Number" column types
+## Be cautious with libraries containing a large number of files(might take too much time to run everything once). consider using the start and end point options to process items in batches.
+
+# Prerequisites
+## Install PnP.PowerShell and make sure you have the necessary permissions to make changes to the files in the library.
+## Confirm that the library is set up with consistent metadata fields on the folders. !!If there is no metadata on the parent folder, the metadata on its child files will be removed!!
+
+# Note
+## Files at the root level of the library will not be updated since they don’t have a parent folder to inherit metadata from.
+
+# Variables: Parameters for running the script
+Param(
+    [Parameter(Mandatory = $true)]
+    [string]$clientId, # Azure AD application client ID
+    [Parameter(Mandatory = $true)]
+    [string]$siteUrl, # URL of the SharePoint site
+    [Parameter(Mandatory = $true)]
+    [string]$libraryName, # Name of the document library
+    [Parameter(Mandatory = $true)]
+    [string[]]$fieldsToCheck, # Metadata fields we want to copy to the files
+    [Parameter()]
+    [int]$startId = -1, # Optional: Start point for file IDs, default value of -1
+    [Parameter()]
+    [int]$endId = -1 # Optional: End point for file IDs, default value of -1
+)
+
+# Connecting to SharePoint Online
+Connect-PnPOnline -Url $siteUrl -Interactive -ClientId $clientId
+
+# Fetch files from the library based on the provided start and end IDs
+if (($startId -ne -1) -and ($endId -ne -1)) {
+    $queryGetPnpListItem = @"
+  <View Scope='RecursiveAll'>
+    <Query>
+        <Where>
+          <And>
+            <Geq>
+              <FieldRef Name='ID'/>
+              <Value Type='Number'>$startId</Value>
+            </Geq>
+            <Lt>
+              <FieldRef Name='ID'/>
+              <Value Type='Number'>$endId</Value>
+            </Lt>
+          </And>
+        </Where>
+    </Query>
+  </View>
+"@
+    $files = Get-PnPListItem -List $libraryName -Query $queryGetPnpListItem -PageSize 1000
+}
+else {
+    # Fetch all files if no ID range is specified
+    $files = Get-PnPListItem -List $libraryName -PageSize 1000
+}
+
+# Process each file and update metadata based on parent folder
+foreach ($fileItem in $files) {
+    $fileName = $fileItem["FileLeafRef"]
+
+    #skip folders, we only want to update files
+    if ($fileItem.FileSystemObjectType -eq "Folder") {
+        continue
+    }
+
+    $parentFolderUrl = $fileItem.FieldValues["FileDirRef"] # URL of the parent folder
+
+    # Query to get parent folder metadata
+    $query = @"
+<View Scope='RecursiveAll'>
+  <Query>
+    <Where>
+      <And>
+        <Eq>
+          <FieldRef Name='FSObjType'/>
+          <Value Type='Integer'>1</Value>
+        </Eq>
+        <Eq>
+          <FieldRef Name='FileRef'/>
+          <Value Type='Text'>$parentFolderUrl</Value>
+        </Eq>
+      </And>
+    </Where>
+  </Query>
+</View>
+"@
+
+    try {
+        $folderItem = Get-PnPListItem -List $libraryName -Query $query
+    }
+    catch {
+        Write-Host "Failed to retrieve folder item for $parentFolderUrl : $_"
+        continue
+    }
+
+    $folderMetadata = $folderItem.FieldValues
+    $fileMetadata = $fileItem.FieldValues
+    $metadataToUpdate = @{}
+
+    # Compare folder metadata with file metadata
+    foreach ($field in $fieldsToCheck) {
+        if ($folderMetadata.ContainsKey($field) -and $folderMetadata[$field] -ne $fileMetadata[$field]) {
+            # Handle managed metadata fields differently, TermGuid is needed to update metadata
+            if ($folderMetadata[$field] -is [Microsoft.SharePoint.Client.Taxonomy.TaxonomyFieldValue]) {
+                if ($folderMetadata[$field].Label -ne $fileMetadata[$field].Label) {
+                    $termGuid = $folderMetadata[$field].TermGuid
+                    $metadataToUpdate[$field] = $termGuid
+                }
+            }
+            else {
+                $metadataToUpdate[$field] = $folderMetadata[$field]
+            }
+        }
+    }
+
+    # Update file metadata if there are changes
+    if ($metadataToUpdate.Count -gt 0) {
+        try {
+            Set-PnPListItem -List $libraryName -Identity $fileItem.Id -Values $metadataToUpdate
+        }
+        catch {
+            Write-Host "Failed to update metadata for file: $fileName - $_"
+        }
+    }
+}

--- a/PowerShell/toc.yml
+++ b/PowerShell/toc.yml
@@ -22,3 +22,5 @@
   href: Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.md
 - name: Set-DefaultValuesFolder
   href: Set-DefaultValuesFolder/Set-DefaultValuesFolder.md
+- name: Set-FileMetadataFromParentFolder
+  href: Set-FileMetadataFromParentFolder/Set-FileMetadataFromParentFolder.md


### PR DESCRIPTION
## Set File metadata based on parent folder
Thanks for submitting a new PowerShell script to the `dw-script-lib`. We really appreciate your contribution. Before completing this pull request, we have a small checklist that will ensure consistency and quality in the library. Make sure you complete all items on the list. 

 - [X] Your script is added to a new folder inside the `powershell` subdirectory
 - [X] The folder contains 1 PowerShell file
 - [X] The PowerShell file follows the correct naming convention
 - [X] The folder contains 1 Readme file
 - [X] The readme file is based on the correct template