### PR TITLE
add: Export term set script

### DIFF
--- a/PowerShell/Export-TermSet/Export-TermSet.md
+++ b/PowerShell/Export-TermSet/Export-TermSet.md
@@ -1,0 +1,50 @@
+# Export-TermSet
+
+## SYNOPSIS
+Exports all terms from a specified Term Set in SharePoint Online, including their labels and translations, to a CSV file.
+
+## SOURCE
+https://github.com/dlw-digitalworkplace/dw-script-lib/tree/main/PowerShell/Export-TermSet
+
+## AUTHOR
+ - Name: Robin Agten
+ - Email: robin.agten@delaware.pro
+
+## SYNTAX
+### Export-TermSet (Default)
+```powershell
+Export-TermSet -ClientId <String> -TenantName <String> -TermGroupName <String> -TermSetName <String> [-OutputPath <String>] [-LocaleIds <Int[]>]
+```
+
+## Prerequisites
+- PowerShell version 7
+- PnP PowerShell module installed (version 2.12 or higher)
+- SharePoint Online tenant admin credentials
+- Permissions to access the specified Term Set in SharePoint Online
+
+## Description
+This script connects to SharePoint Online using the PnP PowerShell module and exports all terms from a specified Term Set to a CSV file. It includes term details such as term ID, name, path, and labels (default and non-default) for specified locale IDs. The output file is saved to the specified path or the script's root directory.
+
+## EXAMPLES
+
+### EXAMPLE 1
+Export terms from a Term Set without specifying locale IDs.
+```powershell
+Export-TermSet -ClientId "your-client-id" -TenantName "your-tenant-name" -TermGroupName "GroupName" -TermSetName "SetName"
+```
+
+### EXAMPLE 2
+Export terms from a Term Set with locale-specific labels.
+```powershell
+Export-TermSet -ClientId "your-client-id" -TenantName "your-tenant-name" -TermGroupName "GroupName" -TermSetName "SetName" -LocaleIds 1033,1036
+```
+
+### EXAMPLE 3
+Export terms to a custom output path.
+```powershell
+Export-TermSet -ClientId "your-client-id" -TenantName "your-tenant-name" -TermGroupName "GroupName" -TermSetName "SetName" -OutputPath "C:\Exports"
+```
+
+## Tags
+ * SharePoint
+ * Taxonomy

--- a/PowerShell/Export-TermSet/Export-TermSet.ps1
+++ b/PowerShell/Export-TermSet/Export-TermSet.ps1
@@ -82,4 +82,4 @@ $outputFilePath = "$output/$TermGroupName-$TermSetName.csv"
 $allTermObjects | Export-Csv -Path "$output/$TermGroupName-$TermSetName.csv" -NoTypeInformation -Encoding Unicode -Delimiter ";"
 
 # Print the full path to the console
-Write-Output -f green "The CSV file has been saved to: $outputFilePath"
+Write-Host -f green "The CSV file has been saved to: $outputFilePath"

--- a/PowerShell/Export-TermSet/Export-TermSet.ps1
+++ b/PowerShell/Export-TermSet/Export-TermSet.ps1
@@ -1,0 +1,85 @@
+param ( 
+      [Parameter(Mandatory=$true)][string]$ClientId,
+      [Parameter(Mandatory=$true)][string]$TenantName,
+      [Parameter(Mandatory=$true)][string]$TermGroupName,
+      [Parameter(Mandatory=$true)][string]$TermSetName,
+      [Parameter(Mandatory=$false)][string]$OutputPath,
+      [Parameter(Mandatory=$false)][int[]]$LocaleIds
+)
+
+# Connect to SharePoint Online
+$tenantUrl = "https://$TenantName-admin.sharepoint.com"
+Write-Host -f yellow "Connecting to SharePoint online: '$tenantUrl'"
+Connect-PnPOnline -Url $tenantUrl -ClientId $ClientId -Interactive -Verbose
+
+# Initialize an empty array to store term objects
+$allTermObjects = New-Object System.Collections.ArrayList
+
+# Function to get term details recursively
+function Get-Term {
+    param ( [string]$termId, [int[]]$LocaleIds )
+
+    # Process main term
+    $mainTerm = Get-PnPTerm -Identity $termId -TermSet $TermSetName -TermGroup $TermGroupName -Includes Labels,PathOfTerm -IncludeChildTerms -Recursive
+    $pathOfTerm = $mainTerm.PathOfTerm -replace ";", "|"
+    Write-Host -f magenta "Processing term with: '$($mainTerm.Id)' - $pathOfTerm"
+
+    # Set base term properties
+    $termData = [ordered] @{
+        "TermId" = $mainTerm.Id
+        "TermName" = $mainTerm.Name
+        "PathOfTerm" = $pathOfTerm
+    }
+
+    # Process labels/translations
+    if ($PSBoundParameters.ContainsKey("LocaleIds")) {
+        foreach ($localeId in $LocaleIds) {
+            Write-Host -f yellow "  Adding labels for locale: '$localeId'"
+        
+            # Get the default label for the locale
+            $defaultLabel = $mainTerm.Labels | Where-Object { $_.Language -eq $localeId -and $_.IsDefaultForLanguage -eq $True }
+            $defaultLabelSafe = (!$defaultLabel.Value ? $null : $defaultLabel.Value) ?? "-"
+
+            # Get the non default labels for the locale
+            $nonDefaultLabels = $mainTerm.Labels | Where-Object { $_.Language -eq $localeId -and $_.IsDefaultForLanguage -eq $False } 
+            $nonDefaultLabelsMerged = ($nonDefaultLabels | ForEach-Object { $_.Value }) -join '|'
+            $nonDefaultLabelsSafe = (!$nonDefaultLabelsMerged ? $null : $nonDefaultLabelsMerged) ?? "-"
+            
+            # Add the labels to the data
+            $termData.Add("$($localeId)_default", $defaultLabelSafe)
+            $termData.Add("$($localeId)_other", $nonDefaultLabelsSafe)
+        }
+
+    }
+    
+    # Add the data to the global list of items
+    $allTermObjects.Add($termData) | Out-Null
+
+    # Process children if any
+    if ($mainTerm.TermsCount -gt 0) {
+      $childTerms = $mainTerm.Terms
+      foreach ($t in $childTerms) {
+          Get-Term -termId $t.Id -LocaleIds $LocaleIds
+      }
+    }    
+}
+
+# Get all terms in the term set
+$allTerms = Get-PnPTerm -TermSet $TermSetName -TermGroup $TermGroupName
+foreach ($term in $allTerms) {
+    Get-Term -termId $term.Id -LocaleIds $LocaleIds
+}
+
+# Disconnect from the service
+Disconnect-PnPOnline
+
+# Build the export path
+$output = $PSScriptRoot
+if ($PSBoundParameters.ContainsKey("OutputPath")) { $output = $OutputPath }
+$outputFilePath = "$output/$TermGroupName-$TermSetName.csv"
+
+# Export the data to CSV
+$allTermObjects | Export-Csv -Path "$output/$TermGroupName-$TermSetName.csv" -NoTypeInformation -Encoding Unicode -Delimiter ";"
+
+# Print the full path to the console
+Write-Output -f green "The CSV file has been saved to: $outputFilePath"

--- a/PowerShell/toc.yml
+++ b/PowerShell/toc.yml
@@ -1,9 +1,13 @@
+- name: Add-GraphPermissionsToManagedIdentity
+  href: Add-GraphPermissionsToManagedIdentity/Add-GraphPermissionsToManagedIdentity.md
 - name: Add-TermGroupSPAdmin
   href: Add-TermGroupSPAdmin/Add-TermGroupSPAdmin.md
 - name: Assign-FieldCustomizerExtension
   href: Assign-FieldCustomizerExtension/Assign-FieldCustomizerExtension.md
 - name: Copy-FolderToDifferentSiteDifferentTenant
   href: Copy-FolderToDifferentSiteDifferentTenant/Copy-FolderToDifferentSiteDifferentTenant.md
+- name: Export-TermSet
+  href: Export-TermSet/Export-TermSet.md
 - name: Explore-MicrosoftGraphModule
   href: Explore-MicrosoftGraphModule/Explore-MicrosoftGraphModule.md
 - name: Import-KeyVaultFromExcel
@@ -16,8 +20,6 @@
   href: Restore-DeletedTermSet/Restore-DeletedTermSet.md
 - name: Set-TeamsPolicyToAadGroup
   href: Set-TeamsPolicyToAadGroup/Set-TeamsPolicyToAadGroup.md
-- name: Add-GraphPermissionsToManagedIdentity
-  href: Add-GraphPermissionsToManagedIdentity/Add-GraphPermissionsToManagedIdentity.md
 - name: Set-DirectoryClassificationSetting
   href: Set-DirectoryClassificationSetting/Set-DirectoryClassificationSetting.md
 - name: Set-DefaultValuesFolder


### PR DESCRIPTION
## Export-TermSet
 - [x] Your script is added to a new folder inside the `powershell` subdirectory
 - [x] The folder contains 1 PowerShell file
 - [x] The PowerShell file follows the correct naming convention
 - [x] The folder contains 1 Readme file
 - [x] The readme file is based on the correct template

This script connects to SharePoint Online using the PnP PowerShell module and exports all terms from a specified Term Set to a CSV file. It includes term details such as term ID, name, path, and labels (default and non-default) for specified locale IDs. The output file is saved to the specified path or the script's root directory.